### PR TITLE
[WIP] Implement a `preStop` lifecyle hook helper for clean shutdown.

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -22,9 +22,10 @@ import (
 // basicHandler is a basic Handler implementation.
 type basicHandler struct {
 	http.ServeMux
-	checksMutex     sync.RWMutex
+	mutex           sync.RWMutex
 	livenessChecks  map[string]Check
 	readinessChecks map[string]Check
+	shutdownHooks   map[string]Hook
 }
 
 // NewHandler creates a new basic Handler
@@ -32,9 +33,11 @@ func NewHandler() Handler {
 	h := &basicHandler{
 		livenessChecks:  make(map[string]Check),
 		readinessChecks: make(map[string]Check),
+		shutdownHooks:   make(map[string]Hook),
 	}
 	h.Handle("/live", http.HandlerFunc(h.LiveEndpoint))
 	h.Handle("/ready", http.HandlerFunc(h.ReadyEndpoint))
+	h.Handle("/shutdown", http.HandlerFunc(h.ShutdownEndpoint))
 	return h
 }
 
@@ -46,21 +49,86 @@ func (s *basicHandler) ReadyEndpoint(w http.ResponseWriter, r *http.Request) {
 	s.handle(w, r, s.readinessChecks, s.livenessChecks)
 }
 
+func (s *basicHandler) ShutdownEndpoint(w http.ResponseWriter, r *http.Request) {
+	results, status := s.collectShutdownHooks()
+
+	// TODO: write to the termination log (/dev/termination-log)
+
+	// write out the response code and content type header
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+
+	// unless ?full=1, return an empty body. Kubernetes only cares about the
+	// HTTP status code, so we won't waste bytes on the full body.
+	if r.URL.Query().Get("full") != "1" {
+		w.Write([]byte("{}\n"))
+		return
+	}
+
+	// otherwise, write the JSON body ignoring any encoding errors (which
+	// shouldn't really be possible since we're encoding a map[string]string).
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "    ")
+	encoder.Encode(results)
+}
+
+// collectShutdownHooks runs all the shutdown hooks in parallel and collects
+// their results into a map[string]string and an HTTP status code
+func (s *basicHandler) collectShutdownHooks() (map[string]string, int) {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	// make a result channel big enough to buffer all the results
+	type hookResult struct {
+		name string
+		err  error
+	}
+	results := make(chan hookResult, len(s.shutdownHooks))
+
+	// kick off all the hooks
+	for name, hook := range s.shutdownHooks {
+		go func(name string, hook Hook) {
+			results <- hookResult{name, hook()}
+		}(name, hook)
+	}
+
+	// read the results into a map
+	status := http.StatusOK
+	resultsMap := make(map[string]string)
+
+	for i := 0; i < len(s.shutdownHooks); i++ {
+		result := <-results
+		if result.err == nil {
+			resultsMap[result.name] = "OK"
+		} else {
+			resultsMap[result.name] = result.err.Error()
+			status = http.StatusServiceUnavailable
+		}
+	}
+
+	return resultsMap, status
+}
+
 func (s *basicHandler) AddLivenessCheck(name string, check Check) {
-	s.checksMutex.Lock()
-	defer s.checksMutex.Unlock()
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 	s.livenessChecks[name] = check
 }
 
 func (s *basicHandler) AddReadinessCheck(name string, check Check) {
-	s.checksMutex.Lock()
-	defer s.checksMutex.Unlock()
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
 	s.readinessChecks[name] = check
 }
 
+func (s *basicHandler) AddShutdownHook(name string, hook Hook) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.shutdownHooks[name] = hook
+}
+
 func (s *basicHandler) collectChecks(checks map[string]Check, resultsOut map[string]string, statusOut *int) {
-	s.checksMutex.RLock()
-	defer s.checksMutex.RUnlock()
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
 	for name, check := range checks {
 		if err := check(); err != nil {
 			*statusOut = http.StatusServiceUnavailable

--- a/hook_http.go
+++ b/hook_http.go
@@ -1,0 +1,73 @@
+// Copyright © 2017 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package healthcheck
+
+import (
+	"net/http"
+	"sync"
+	"time"
+)
+
+// httpDrainer wraps an http.Handler to provide a shutdown hook that waits for
+// all active requests to drain.
+type httpDrainer struct {
+	handler          http.Handler
+	minimumQuietTime time.Duration
+
+	mutex    sync.Mutex
+	inflight int
+	quiet    *time.Timer
+}
+
+// ServeHTTP wraps the underlying http.Handler to atomically update the number
+// of requests in flight
+func (d *httpDrainer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+
+	d.mutex.Lock()
+	d.inflight++
+	// before serving the request, cancel the timer
+	// (it can't fire while this request is in flight)
+	d.quiet.Stop()
+	d.mutex.Unlock()
+
+	defer func() {
+		d.mutex.Lock()
+		d.inflight--
+		if d.inflight == 0 {
+			// if we're the last active request, reset the timer to fire after the quiet time
+			d.quiet.Reset(d.minimumQuietTime)
+		}
+		d.mutex.Unlock()
+	}()
+	d.handler.ServeHTTP(w, r)
+}
+
+// hook blocks until there are no active requests
+func (d *httpDrainer) hook() error {
+	<-d.quiet.C
+	return nil
+}
+
+// HTTPDrainHook returns a wrapped http.Handler and a shutdown Hook. It will
+// pass through all requests to the wrapped handler but will track requests in
+// flight. On graceful shutdown, it will block until it has been at least
+// minimumQuietTime since the last request completed.
+func HTTPDrainHook(handler http.Handler, minimumQuietTime time.Duration) (http.Handler, Hook) {
+	d := &httpDrainer{
+		handler:          handler,
+		minimumQuietTime: minimumQuietTime,
+		quiet:            time.NewTimer(minimumQuietTime),
+	}
+	return d, d.hook
+}

--- a/hook_http_test.go
+++ b/hook_http_test.go
@@ -1,0 +1,79 @@
+// Copyright © 2017 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package healthcheck
+
+import (
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const workTime = 500 * time.Millisecond
+const quietTime = 1 * time.Second
+const acceptableDelta = 10 * time.Millisecond
+
+func slowHandler() http.Handler {
+	// create an http.Handler where GET / takes 1s to response
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(workTime)
+		w.WriteHeader(http.StatusOK)
+	})
+	return mux
+
+}
+
+func TestHTTPDrainHookEmpty(t *testing.T) {
+
+	_, hook := HTTPDrainHook(slowHandler(), quietTime)
+
+	// make sure hook() waits for the quietTime to drain
+	start := time.Now()
+	hook()
+	end := time.Now()
+	assert.WithinDuration(t, start.Add(quietTime), end, acceptableDelta,
+		"expected hook() to return after %s but it took %s",
+		quietTime.String(),
+		end.Sub(start).String())
+}
+
+func TestHTTPDrainHook(t *testing.T) {
+	handler, hook := HTTPDrainHook(slowHandler(), quietTime)
+	// kick off a few in-flight requests
+	var wg sync.WaitGroup
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		go func() {
+			assert.HTTPSuccess(t, handler.ServeHTTP, "GET", "/", nil)
+			wg.Done()
+		}()
+	}
+
+	// make sure hook() takes about workTime+quietTime to respond (to finish all
+	// in-flight requests and wait for the quiet time to expire)
+	start := time.Now()
+	hook()
+	end := time.Now()
+	assert.WithinDuration(t, start.Add(workTime+quietTime), end, acceptableDelta,
+		"expected hook() to return after %s but it took %s",
+		quietTime.String(),
+		end.Sub(start).String())
+
+	// wait for all the requests to finish so we can make sure they all succeeded
+	// this should return ~immediately
+	wg.Wait()
+}

--- a/hook_waitgroup.go
+++ b/hook_waitgroup.go
@@ -1,0 +1,40 @@
+// Copyright © 2017 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package healthcheck
+
+import (
+	"context"
+	"sync"
+)
+
+// WaitHook creates a shutdown hook linked to a context.Context and a
+// sync.WaitGroup. Whenever the shutdown hook is called, it signals that event
+// by canceling the Context and waiting until the WaitGroup is done.
+func WaitHook() (context.Context, *sync.WaitGroup, Hook) {
+	return WaitHookWithContext(context.Background())
+}
+
+// WaitHookWithContext creates a shutdown hook linked to a context.Context and a
+// sync.WaitGroup. Whenever the shutdown hook is called, it signals that event
+// by canceling the Context and waiting until the WaitGroup is done. The returned
+// context is a child of the specified parent context.
+func WaitHookWithContext(parent context.Context) (context.Context, *sync.WaitGroup, Hook) {
+	ctx, cancel := context.WithCancel(parent)
+	var wg sync.WaitGroup
+	return ctx, &wg, func() error {
+		cancel()
+		wg.Wait()
+		return nil
+	}
+}

--- a/hook_waitgroup_test.go
+++ b/hook_waitgroup_test.go
@@ -1,0 +1,69 @@
+// Copyright © 2017 Heptio
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package healthcheck
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWaitHook(t *testing.T) {
+	ctx, wg, hook := WaitHook()
+
+	// expect the context to be open (not done)
+	select {
+	case <-ctx.Done():
+		assert.FailNow(t, "expected context not to be done yet")
+	default:
+	}
+
+	// expect this not to block
+	wg.Wait()
+
+	// add a unit of in-flight work
+	wg.Add(1)
+
+	// call hook, which should block
+	result := make(chan error)
+	go func() {
+		result <- hook()
+	}()
+
+	// expect the context to be closed
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Millisecond):
+		assert.FailNow(t, "expected context to be done")
+	}
+
+	// expect the hook to still be blocked
+	select {
+	case <-result:
+		assert.FailNow(t, "expected hook to be blocked while work is in flight")
+	default:
+	}
+
+	// finish the in-flight work
+	wg.Done()
+
+	// expect the hook to have returned nil now that the WorkGroup is done with in-flight work
+	select {
+	case result := <-result:
+		assert.NoErrorf(t, result, "expected hook to have returned nil")
+	case <-time.After(time.Millisecond):
+		assert.FailNow(t, "expected hook to have returned a result")
+	}
+}

--- a/metrics_handler.go
+++ b/metrics_handler.go
@@ -43,6 +43,10 @@ func (h *metricsHandler) AddReadinessCheck(name string, check Check) {
 	h.handler.AddReadinessCheck(name, h.wrap(name, check))
 }
 
+func (h *metricsHandler) AddShutdownHook(name string, hook Hook) {
+	h.handler.AddShutdownHook(name, hook)
+}
+
 func (h *metricsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.handler.ServeHTTP(w, r)
 }
@@ -53,6 +57,10 @@ func (h *metricsHandler) LiveEndpoint(w http.ResponseWriter, r *http.Request) {
 
 func (h *metricsHandler) ReadyEndpoint(w http.ResponseWriter, r *http.Request) {
 	h.handler.ReadyEndpoint(w, r)
+}
+
+func (h *metricsHandler) ShutdownEndpoint(w http.ResponseWriter, r *http.Request) {
+	h.handler.ShutdownEndpoint(w, r)
 }
 
 func (h *metricsHandler) wrap(name string, check Check) Check {


### PR DESCRIPTION
~~This adds a `AddShutdownHook()` method that registers "shutdown hooks" with the Handler. These hooks are called whenever Kubernetes sends a `preStop` event by hitting the `/shutdown` endpoint. All registered hooks run concurrently and can block shutdown for as long as they need (until Kubernetes kills the process).~~

~~The main use case I have for this is letting active HTTP requests drain from a service before it exits. If you just plug a default Go HTTP server into Kubernetes and don't use `preStop` hooks, you can end up terminating some in-flight requests during a deploy (if you have some longer lived requests).~~

### ~~TODO~~
 - ~~Code needs cleanup, not really even ready for review yet.~~
 - ~~Need to implement writing to `/dev/termination-log` (this gets picked up in the terminated pod's metadata so you can see if the pod exited cleanly). It might be useful to give each `Hook` access to a `log.Logger` or something so they can write incremental status to the termination log.~~
 - ~~The library really needs a new name if we add this functionality.~~
 - ~~This shutdown hook stuff could probably be separated into its own library instead, which would just mean having one listener for the readiness/liveness probes and another for the shutdown hook.~~

Edit: see https://github.com/heptio/shutdown/pull/1 instead.