### PR TITLE
Add GCMaxPauseCheck for restarting an app experiencing long GC pauses.

### DIFF
--- a/checks.go
+++ b/checks.go
@@ -88,3 +88,19 @@ func GoroutineCountCheck(threshold int) Check {
 		return nil
 	}
 }
+
+// GCMaxPauseCheck returns a Check that fails if any recent Go garbage
+// collection pause exceeds the provided threshold.
+func GCMaxPauseCheck(threshold time.Duration) Check {
+	thresholdNanoseconds := uint64(threshold.Nanoseconds())
+	return func() error {
+		var stats runtime.MemStats
+		runtime.ReadMemStats(&stats)
+		for _, pause := range stats.PauseNs {
+			if pause > thresholdNanoseconds {
+				return fmt.Errorf("recent GC cycle took %s > %s", time.Duration(pause), threshold)
+			}
+		}
+		return nil
+	}
+}

--- a/checks_test.go
+++ b/checks_test.go
@@ -15,6 +15,7 @@
 package healthcheck
 
 import (
+	"runtime"
 	"testing"
 	"time"
 
@@ -40,4 +41,10 @@ func TestDNSResolveCheck(t *testing.T) {
 func TestGoroutineCountCheck(t *testing.T) {
 	assert.NoError(t, GoroutineCountCheck(1000)())
 	assert.Error(t, GoroutineCountCheck(0)())
+}
+
+func TestGCMaxPauseCheck(t *testing.T) {
+	runtime.GC()
+	assert.NoError(t, GCMaxPauseCheck(1*time.Second)())
+	assert.Error(t, GCMaxPauseCheck(0)())
 }


### PR DESCRIPTION
You can use this to aggressively restart an application (with safe draining) if the GC pause time starts to exceed some threshold.
